### PR TITLE
<fix> safely encode special characters in db_uri passwords

### DIFF
--- a/tools/db_utils.py
+++ b/tools/db_utils.py
@@ -1,0 +1,68 @@
+"""
+数据库工具函数
+"""
+import re
+from urllib.parse import quote_plus
+
+
+def fix_db_uri_encoding(db_uri: str) -> str:
+    """
+    修复数据库 URI 中的特殊字符编码问题
+    特别是处理密码中包含 @ 符号的情况
+    
+    Args:
+        db_uri: 原始数据库 URI
+        
+    Returns:
+        修复后的数据库 URI
+        
+    Examples:
+        >>> fix_db_uri_encoding("postgresql://user:pass@word@localhost:5432/db")
+        'postgresql://user:pass%40word@localhost:5432/db'
+        
+        >>> fix_db_uri_encoding("mysql://user:pass+word@localhost:3306/db")
+        'mysql://user:pass%2Bword@localhost:3306/db'
+    """
+    try:
+        # 使用更精确的正则表达式来解析数据库 URI
+        # 格式: scheme://username:password@host:port/database
+        import re
+        
+        # 匹配数据库 URI 的正则表达式
+        # 使用非贪婪匹配来正确处理密码中的 @ 符号
+        pattern = r'^([^:]+)://([^:]+):(.+)@([^:]+):(\d+)/(.+)$'
+        match = re.match(pattern, db_uri)
+        
+        if match:
+            scheme, username, password, host, port, database = match.groups()
+            
+            # 对用户名和密码进行 URL 编码
+            encoded_username = quote_plus(username)
+            encoded_password = quote_plus(password)
+            
+            # 重建 URI
+            fixed_uri = f"{scheme}://{encoded_username}:{encoded_password}@{host}:{port}/{database}"
+            return fixed_uri
+        else:
+            # 如果没有匹配到标准格式，尝试其他格式
+            # 处理没有端口号的情况
+            pattern_no_port = r'^([^:]+)://([^:]+):(.+)@([^/]+)/(.+)$'
+            match = re.match(pattern_no_port, db_uri)
+            
+            if match:
+                scheme, username, password, host, database = match.groups()
+                
+                # 对用户名和密码进行 URL 编码
+                encoded_username = quote_plus(username)
+                encoded_password = quote_plus(password)
+                
+                # 重建 URI
+                fixed_uri = f"{scheme}://{encoded_username}:{encoded_password}@{host}/{database}"
+                return fixed_uri
+            else:
+                # 如果都不匹配，返回原始 URI
+                return db_uri
+                
+    except Exception:
+        # 如果解析失败，返回原始 URI
+        return db_uri 

--- a/tools/sql_execute.py
+++ b/tools/sql_execute.py
@@ -7,6 +7,7 @@ import records
 from sqlalchemy import text
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
+from tools.db_utils import fix_db_uri_encoding
 
 
 class SQLExecuteTool(Tool):
@@ -14,6 +15,10 @@ class SQLExecuteTool(Tool):
         db_uri = tool_parameters.get("db_uri") or self.runtime.credentials.get("db_uri")
         if not db_uri:
             raise ValueError("Database URI is not provided.")
+        
+        # 修复 db_uri 中的特殊字符编码问题
+        db_uri = fix_db_uri_encoding(db_uri)
+        
         query = tool_parameters.get("query").strip()
         format = tool_parameters.get("format", "json")
         config_options = tool_parameters.get("config_options") or "{}"

--- a/tools/table_schema.py
+++ b/tools/table_schema.py
@@ -5,6 +5,7 @@ import json
 from sqlalchemy import create_engine, inspect
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
+from tools.db_utils import fix_db_uri_encoding
 
 
 class QueryTool(Tool):
@@ -12,6 +13,10 @@ class QueryTool(Tool):
         db_uri = tool_parameters.get("db_uri") or self.runtime.credentials.get("db_uri")
         if not db_uri:
             raise ValueError("Database URI is not provided.")
+        
+        # 修复 db_uri 中的特殊字符编码问题
+        db_uri = fix_db_uri_encoding(db_uri)
+        
         config_options = tool_parameters.get("config_options") or "{}"
         try:
             config_options = json.loads(config_options)

--- a/tools/text2sql.py
+++ b/tools/text2sql.py
@@ -1,11 +1,14 @@
 from collections.abc import Generator
 from typing import Any
 import json
+import re
+from urllib.parse import quote_plus
 
 from sqlalchemy import create_engine, inspect
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from dify_plugin.entities.model.message import SystemPromptMessage, UserPromptMessage
+from tools.db_utils import fix_db_uri_encoding
 
 SYSTEM_PROMPT_TEMPLATE = """
 You are a {dialect} expert. Your task is to generate an executable {dialect} query based on the user's question.
@@ -63,6 +66,10 @@ class QueryTool(Tool):
         db_uri = tool_parameters.get("db_uri") or self.runtime.credentials.get("db_uri")
         if not db_uri:
             raise ValueError("Database URI is not provided.")
+        
+        # 修复 db_uri 中的特殊字符编码问题
+        db_uri = fix_db_uri_encoding(db_uri)
+        
         config_options = tool_parameters.get("config_options") or "{}"
         try:
             config_options = json.loads(config_options)


### PR DESCRIPTION
1.1 Issue Reproduction
Confirmed authentication failures when passwords contain @, /, = symbols
Traced root cause to URI parser's special character handling

1.2 Impact Assessment
Affected: All database connections with special characters in credentials